### PR TITLE
[NET-0098] Fix Lint Github Action for NextJS FE App

### DIFF
--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -62,8 +62,6 @@ jobs:
       - name: Install Dependencies
         working-directory: ./inventory-web-app
         run: yarn
-      - uses: sibiraj-s/action-eslint@v2
-        with:
-          eslint-args: '--ignore-path=.gitignore --quiet'
-          extensions: 'js,jsx,ts,tsx'
-          annotations: true
+      - name: Run ESLint for inventory-web-app directory
+        working-directory: ./inventory-web-app
+        run: npx yarn lint

--- a/inventory-web-app/pages/index.js
+++ b/inventory-web-app/pages/index.js
@@ -25,6 +25,7 @@ export default function Home() {
           Welcome to <a href="https://nextjs.org">Next.js!</a>
         </h1>
 
+
         <Form
           name="basic"
           labelCol={{ span: 8 }}

--- a/inventory-web-app/pages/index.js
+++ b/inventory-web-app/pages/index.js
@@ -25,7 +25,6 @@ export default function Home() {
           Welcome to <a href="https://nextjs.org">Next.js!</a>
         </h1>
 
-
         <Form
           name="basic"
           labelCol={{ span: 8 }}


### PR DESCRIPTION
## Description
Optional Short summary of this PR. May also use any of the fields below to relay information.


**RCA:** sibiraj-s/action-eslint does not work for node_modules that are in the sub-directory


**Resolution:** Revert to using a script, and use the built in linter for next (lint script in package.json = 'next lint')


**Changelog:**
- [x] Use NextJS linter for Lint Github Action for the nextjs app directory